### PR TITLE
横移動入力が補正なしで反映されるように修正した

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -48,8 +48,8 @@ public class PlayerController : MonoBehaviour
     void Update()
     {
         //ˆÚ“®ƒL[“ü—Íæ“¾
-        float horizontalKey = Input.GetAxis("Horizontal");
-        float verticalKey = Input.GetAxis("Vertical");
+        float horizontalKey = Input.GetAxisRaw("Horizontal");
+        float verticalKey = Input.GetAxisRaw("Vertical");
         //’n–Ê‚Æ‚ÌÚG”»’è‚Ìæ“¾
         bool isGround = ground.IsGround();
         bool isHead = head.IsGround();


### PR DESCRIPTION
## issue番号
#12
## 実装したこと
横移動入力の補正を消し、ボタンを放した瞬間にキャラが止まるようにした
## 注意点(あれば)

